### PR TITLE
Fix EOF parsing bug: flush final translation section in initialize_translation

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -572,7 +572,7 @@ pub struct Base {
 impl Default for Base {
     fn default() -> Self {
         Self {
-            mode: Mode::Read(ReadMode::Default { force: false }),
+            mode: Mode::Read(ReadMode::Default(false)),
             flags: BaseFlags::empty(),
             game_type: GameType::None,
             engine_type: EngineType::New,
@@ -1265,6 +1265,38 @@ impl<'a> Base {
                     translation: translation.into(),
                 },
             );
+        }
+
+        // Flush the last parsed section at EOF.
+        // Without this, the final `<!-- ID --><#>...` block is dropped if there
+        // is no following ID marker to trigger the regular section flush path.
+        if id != 0 {
+            let mut skip_entry = false;
+
+            if self.translation_map.is_empty() {
+                let metadata_entry = self
+                    .metadata
+                    .entry(id)
+                    .or_insert(replace(&mut comments, smallvec![String::new(); 3]));
+
+                let display_name = &metadata_entry[DISPLAY_NAME_POS];
+
+                if self.mode.is_write()
+                    && (display_name.is_empty()
+                        || display_name.ends_with(SEPARATOR))
+                {
+                    skip_entry = true;
+                } else {
+                    self.translation_maps
+                        .entry(id)
+                        .or_insert(TranslationMap::with_capacity(512));
+                }
+            }
+
+            if !skip_entry {
+                self.translation_maps
+                    .insert(id, self.translation_map.drain(..).collect());
+            }
         }
 
         unsafe {

--- a/src/core.rs
+++ b/src/core.rs
@@ -572,7 +572,7 @@ pub struct Base {
 impl Default for Base {
     fn default() -> Self {
         Self {
-            mode: Mode::Read(ReadMode::Default(false)),
+            mode: Mode::Read(ReadMode::Default { force: false }),
             flags: BaseFlags::empty(),
             game_type: GameType::None,
             engine_type: EngineType::New,


### PR DESCRIPTION
## Summary
This PR fixes an EOF parsing bug in `initialize_translation()` where the last translation section was dropped if the file ended without a following `<!-- ID -->` marker.

## Problem
The parser currently flushes the current `translation_map` only when it encounters a new `ID_COMMENT` line.  
As a result, the final section at EOF is never inserted into `translation_maps`.

Typical symptom:
- The last map block exists in `maps.txt` with valid translations.
- Write/export reports success.
- The corresponding final output map is missing or not updated.

## Root cause
In `initialize_translation()`:
- section flush logic exists in the `if line.starts_with(ID_COMMENT)` branch,
- but there is no equivalent final flush after the loop.

## Fix
- Add an explicit final flush after the parsing loop when `id != 0`.
- Reuse the same write-mode guards for metadata/display-name validity used in the normal section-flush path.
- Do not introduce sentinels, fake IDs, or hardcoded workaround values.

## Scope
- Parser logic only (`core.rs`).
- No behavioral change outside EOF final-section handling.

## Expected result
- The final translation section is correctly applied at EOF.
- Last map/text block is no longer silently ignored during write/export.

Refs #17 
Fix #17 